### PR TITLE
Add AdaptiveImage.toString to compatible IMG tag

### DIFF
--- a/src/modules/adaptiveImage.js
+++ b/src/modules/adaptiveImage.js
@@ -19,6 +19,9 @@ AdaptiveImage.prototype = {
     },
     get height() {
         return this.data.height
+    },
+    toString() {
+        return this.data.uri
     }
 }
 


### PR DESCRIPTION
Some modules used Image of react-native-web, and other modules used IMG tag. Currently IMG tag generates `<img src="[object Object]">`, we can provide `toString` to returns `uri`, and then it generates DOM likes `<img src="/730af0af72d9c903286a9e306fc7f848.png">`.